### PR TITLE
Force gunicorn version 19.9.0 to prevent k8s  issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flask
 requests
-gunicorn
+gunicorn==19.9.0


### PR DESCRIPTION
Kubernetes is unable to kill gunicorn. Force Version 19.9.0 to prevent this.